### PR TITLE
Add custom value for coin drops when idle

### DIFF
--- a/plugins/coins/manifest.json
+++ b/plugins/coins/manifest.json
@@ -69,7 +69,14 @@
 				"description": "Minutes of inactivity after which a user is considered idle/lurking.",
 				"default": 10,
 				"type": "number"
-			}			
+			},
+			"idleDropValue": {
+				"name": "Idle Drop Value",
+				"category": "Idlers/Lurkers",
+				"description": "Value of a single coin drop for idlers/lurkers.",
+				"default": 10,
+				"type": "number"
+			}
 		}
 	}
 }

--- a/plugins/coins/plugin.iced
+++ b/plugins/coins/plugin.iced
@@ -52,7 +52,7 @@ updateCoins = () =>
 						Viewer = new Mikuia.Models.Channel viewer
 						goAhead = true
 
-						idle = not chatActivity[viewer]?[stream] > 0
+						idle = not (chatActivity[viewer]?[stream] > 0)
 						if not rewardIdlers and idle
 							goAhead = false
 


### PR DESCRIPTION
Allows the user to configure a different coin drop value for idlers/lurkers. Now with a clean commit...

Editor gets rid of unnecessary whitespace, that's why there's a few useless changes there.